### PR TITLE
Add SetAlpha method to Image and SpriteSheet classes

### DIFF
--- a/include/Util/Image.hpp
+++ b/include/Util/Image.hpp
@@ -73,6 +73,8 @@ public:
      */
     void UpdateTextureData(const SDL_Surface &surface);
 
+    void SetAlpha(const Uint8 alpha);
+
 private:
     void InitProgram();
     void InitVertexArray();

--- a/include/Util/SpriteSheet.hpp
+++ b/include/Util/SpriteSheet.hpp
@@ -47,9 +47,13 @@ public:
 
     void RestDrawRect();
 
+    void SetAlpha(const Uint8 alpha);
+
 private:
     std::unique_ptr<Image> m_Image;
     SDL_Rect m_OriginRect;
+    SDL_Rect m_DisplayRect;
+    Uint8 m_Alpha = 255;
 };
 
 } // namespace Util


### PR DESCRIPTION
This pull request adds a SetAlpha method to the Image and SpriteSheet classes. The SetAlpha method allows setting the alpha value of the image or sprite sheet, which controls the transparency of the rendered image. This feature is useful for creating fade-in or fade-out effects in games or applications.